### PR TITLE
NetteLatteFilter: Object access allowed

### DIFF
--- a/GettextExtractor/Filters/NetteLatteFilter.php
+++ b/GettextExtractor/Filters/NetteLatteFilter.php
@@ -27,10 +27,10 @@ class GettextExtractor_Filters_NetteLatteFilter extends GettextExtractor_Filters
 	/** @internal PHP identifier, from Nette\Templates\LatteFilter */
 	const RE_IDENTIFIER = '[_a-zA-Z\x7F-\xFF][_a-zA-Z0-9\x7F-\xFF]*';
 
-	const RE_ARGS = '(\(.*?\))?';
+	const RE_ARGS = '\(.*?\)';
 	const RE_FUNCTION = '__IDENTIFIER____ARGS__(?:->__IDENTIFIER____ARGS__)*'; // Function can return object, so fluent interface is applicable
 	const RE_KEY = '\[.*?\]';
-	const RE_VARIABLE = '\$__IDENTIFIER__(?:__KEY__)*(?:__ARGS__)?(?:->__FUNCTION__)?'; // It's possible to access multidimensional array, variable functions and objects' fluent interface
+	const RE_VARIABLE = '\$__IDENTIFIER__(?:__KEY__)*(?:__ARGS__)?(?:->(?:__IDENTIFIER__|__FUNCTION__|__VARIABLE__)*)?'; // It's possible to access multidimensional array, variable functions and objects' fluent interface
 	const RE_STATIC = '__IDENTIFIER__(?:::(?:__IDENTIFIER__|__FUNCTION__|__VARIABLE__))?';
 
 	const RE_MODIFIER = '\\s*\|[^|}]+';

--- a/tests/unit/GettextExtractor/Filters/NetteLatteFilterTest.php
+++ b/tests/unit/GettextExtractor/Filters/NetteLatteFilterTest.php
@@ -42,6 +42,10 @@ class GettextExtractor_Filters_NetteLatteFilterTest extends GettextExtractor_Fil
 			GettextExtractor_Extractor::LINE => 1,
 			GettextExtractor_Extractor::SINGULAR => 'Testovaci retezec'
 		), $messages);
+		$this->assertContains(array(
+			GettextExtractor_Extractor::LINE => 2,
+			GettextExtractor_Extractor::SINGULAR => 'Object access %d'
+		), $messages);
 
 		$this->assertNotContains(array(
 			GettextExtractor_Extractor::LINE => 3,
@@ -76,6 +80,11 @@ class GettextExtractor_Filters_NetteLatteFilterTest extends GettextExtractor_Fil
 		$this->assertNotContains(array(
 			GettextExtractor_Extractor::LINE => 9,
 			GettextExtractor_Extractor::SINGULAR => '$object->method()'
+		), $messages);
+		
+		$this->assertNotContains(array(
+			GettextExtractor_Extractor::LINE => 9,
+			GettextExtractor_Extractor::SINGULAR => '$object->attribute'
 		), $messages);
 
 		$this->assertNotContains(array(

--- a/tests/unit/data/test.latte
+++ b/tests/unit/data/test.latte
@@ -1,4 +1,6 @@
-{_'Testovaci retezec', 69, 'Jiny retezec', CONSTANT, Class::CONSTANT, Class::$var[0]['key']($arg)->method()->method(), Class::method(), $var, $array[0], $varFunc(), $object->method(), function(), function()->fluent()}
+{_'Testovaci retezec', 69, 'Jiny retezec', CONSTANT, Class::CONSTANT, Class::$var[0]['key']($arg)->method()->method(), $object->attribute, Class::method(), $var, $array[0], $varFunc(), $object->method(), function(), function()->fluent()}
+{_'Object access %d', $object->access}
+	
 Zkusit pretypovani (bool) $var.
 {_69}
 {_CONSTANT}
@@ -7,6 +9,7 @@ Zkusit pretypovani (bool) $var.
 {_$array[0]}
 {_$varFunc()}
 {_$object->method()}
+{_$object->attribute}
 {_function()}
 {_function()->fluent()}
 {_Class::$var[0]['key']($arg)->method()->method()}


### PR DESCRIPTION
Previously only fluents was supported
