### PR TITLE
Bump latte version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	},
 	"require": {
 		"php": ">=7.2.0",
-		"latte/latte": "~2.5.0",
+		"latte/latte": "^2.5",
 		"nette/utils": "^3.0",
 		"nikic/php-parser": "^4.2"
 	},


### PR DESCRIPTION
Hi, we run into errors while trying to update our composer dependencies.

Tests are passing, it should be safe to update as no BC breaks are introduced in minor versions.

<img width="1398" alt="Screenshot 2020-01-28 13 33 40" src="https://user-images.githubusercontent.com/3995003/73264335-d292e000-41d2-11ea-8190-99edb162444c.png">
