### PR TITLE
Support for concatenated strings in PHP files

### DIFF
--- a/src/Filters/PHPFilter.php
+++ b/src/Filters/PHPFilter.php
@@ -97,6 +97,8 @@ class PHPFilter extends AFilter implements IFilter, PhpParser\NodeVisitor {
 				if (count($message) === 1) { // line only
 					return;
 				}
+			} elseif ($arg instanceof Node\Expr\BinaryOp\Concat) {
+				$message[$type] = $this->processConcatenatedString($arg);
 			} else {
 				return;
 			}
@@ -110,6 +112,23 @@ class PHPFilter extends AFilter implements IFilter, PhpParser\NodeVisitor {
 		} else {
 			$this->data[] = $message;
 		}
+	}
+
+	private function processConcatenatedString(Node\Expr\BinaryOp\Concat $arg): string
+	{
+		$result = '';
+
+		if ($arg->left instanceof Node\Expr\BinaryOp\Concat) {
+			$result .= $this->processConcatenatedString($arg->left);
+		} elseif ($arg->left instanceof String_) {
+			$result .= $arg->left->value;
+		}
+
+		if ($arg->right instanceof String_) {
+			$result .= $arg->right->value;
+		}
+
+		return $result;
 	}
 
 	/* PhpParser\NodeVisitor: dont need these *******************************/

--- a/tests/unit/GettextExtractor/Filters/PHPFilterTest.php
+++ b/tests/unit/GettextExtractor/Filters/PHPFilterTest.php
@@ -95,6 +95,24 @@ class PHPFilterTest extends TestCase {
 		), $messages);
 	}
 
+	/** @dataProvider provideConcatenatedMessageFiles */
+	public function testConcatenatedMessage(string $phpFile): void {
+		$messages = $this->object->extract($phpFile);
+		self::assertContains(array(
+			GE\Extractor::LINE => 2,
+			GE\Extractor::SINGULAR => "A message!"
+		), $messages);
+	}
+
+	/** @return array<string, string[]> */
+	public function provideConcatenatedMessageFiles(): array {
+		return [
+			'String on one lines' => [__DIR__ . '/../../data/php/concatenatedMessageOneLine.php'],
+			'String on two lines' => [__DIR__ . '/../../data/php/concatenatedMessageTwoLines.php'],
+			'String on multiple lines with empty parts' => [__DIR__ . '/../../data/php/concatenatedMessageMultipleLines.php'],
+		];
+	}
+
 	public function testArrayAsParameter(): void {
 		$this->object->addFunction('addConfirmer', 3);
 		$messages = $this->object->extract(__DIR__ . '/../../data/php/arrayAsParameter.php');

--- a/tests/unit/data/php/concatenatedMessageMultipleLines.php
+++ b/tests/unit/data/php/concatenatedMessageMultipleLines.php
@@ -1,0 +1,6 @@
+<?php
+$translator->gettext('A ' .
+
+	'mess'
+
+. 'age' . '' . '!' . '');

--- a/tests/unit/data/php/concatenatedMessageOneLine.php
+++ b/tests/unit/data/php/concatenatedMessageOneLine.php
@@ -1,0 +1,2 @@
+<?php
+$translator->gettext('A ' . 'message!');

--- a/tests/unit/data/php/concatenatedMessageTwoLines.php
+++ b/tests/unit/data/php/concatenatedMessageTwoLines.php
@@ -1,0 +1,3 @@
+<?php
+$translator->gettext('A '
+. 'message!');


### PR DESCRIPTION
Added support for parsing concatenated strings, like:

```
$translator->gettext('A ' . 'message!');
```

```
$translator->gettext('A '
. 'message!');
```
....